### PR TITLE
Fix tasks flag `--allow-net`

### DIFF
--- a/deno.novaextension/extension.json
+++ b/deno.novaextension/extension.json
@@ -187,7 +187,7 @@
               "default": false
             },
             {
-              "key": "co.gwil.deno.tasks.run.config.allow.network",
+              "key": "co.gwil.deno.tasks.run.config.allow.net",
               "title": "Allow network access",
               "type": "boolean",
               "default": false

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -26,7 +26,7 @@ class DenoRunTaskAssistant implements TaskAssistant {
     const permissionTuples = ([
       ["co.gwil.deno.tasks.run.config.allow.read", "--allow-read"],
       ["co.gwil.deno.tasks.run.config.allow.write", "--allow-write"],
-      ["co.gwil.deno.tasks.run.config.allow.network", "--allow-network"],
+      ["co.gwil.deno.tasks.run.config.allow.net", "--allow-net"],
       ['"co.gwil.deno.tasks.run.config.allow.run"', "--allow-run"],
       ["co.gwil.deno.tasks.run.config.allow.env", "allow-env"],
     ] as [string, string][]).map(([key, flag]) => configToMaybeFlag(key, flag))


### PR DESCRIPTION
The flag was incorrectly `--allow-network`, when it should be `--allow-net`. See: https://deno.land/manual@v1.12.2/getting_started/permissions#permissions-list .

This should fix this crash when attempting a run task with network allowed:

<img width="648" alt="Screen Shot 2021-08-03 at 11 55 01 am" src="https://user-images.githubusercontent.com/1754873/127945439-57d6245d-3ceb-47c6-8b18-38fbc6077f7a.png">

I'm not sure how to test this, so please review carefully 🙏