### PR TITLE
Do not log LSP logs as errors

### DIFF
--- a/src/nova_deno.ts
+++ b/src/nova_deno.ts
@@ -19,7 +19,7 @@ export function activate() {
       type: "stdio",
       path: "/usr/bin/env",
       //args: ["bash", "-c", `tee "${inLog}" | deno lsp | tee "${outLog}"`],
-      args: ["deno", "lsp"],
+      args: ["deno", "lsp", "--quiet"],
     },
     {
       syntaxes,


### PR DESCRIPTION
Fixes #12. Seems that Deno will print all logs to `stderr` unless you pass a `--quiet` flag to it.