### PR TITLE
fix: format on save issue applying workspace configuration

### DIFF
--- a/src/nova_deno.ts
+++ b/src/nova_deno.ts
@@ -105,7 +105,9 @@ export function activate() {
         }
 
         return editor.onWillSave(async () => {
-          if (nova.config.get("co.gwil.deno.config.formatOnSave") === false) {
+          if (
+            getOverridableBoolean("co.gwil.deno.config.formatOnSave") === false
+          ) {
             return;
           }
 


### PR DESCRIPTION
The language server, linting, and unstable APIs can be enabled at a workspace level, but formatting on save can only be configured at the global level. This causes issues when you've got other formatters enabled. I think this was a simple fix, as the workspace configuration was not being applied when formatting on save. I've used the available `getOverridableBoolean` function to override the global setting if the workspace setting has been configured.