### PR TITLE
Do not provide language features while "Enable Deno Language Features" is turned off

### DIFF
--- a/src/client_disposable.ts
+++ b/src/client_disposable.ts
@@ -54,7 +54,7 @@ export function makeClientDisposable(parentDisposable: CompositeDisposable) {
     {
       syntaxes,
       initializationOptions: {
-        enable: getOverridableBoolean("co.gwil.deno.config.enableLsp") || true,
+        enable: getOverridableBoolean("co.gwil.deno.config.enableLsp"),
         lint: getOverridableBoolean("co.gwil.deno.config.enableLinting"),
         unstable: getOverridableBoolean("co.gwil.deno.config.enableUnstable"),
         importMap: nova.workspace.config.get("co.gwil.deno.config.import-map"),


### PR DESCRIPTION
This OR operator might have been making the expression evaluate to `true` regardless of the value of the setting. I’m not quite sure of why it was added; I was thinking of replacing it with ??, but the call to `getOverridableBoolean` should never return null, right?

Either way, removing that bit of code seems to fix it.

https://user-images.githubusercontent.com/73370025/163702666-52e109ff-6ac0-4843-8c2e-5ad53e127b2b.mp4


https://user-images.githubusercontent.com/73370025/163702708-ceb551d3-b425-4379-90ed-ecb4c7ee7e04.mp4


