### PR TITLE
Resolve #22, #20

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,2 @@
 export * as lsp from "https://cdn.skypack.dev/vscode-languageserver-types?dts";
+export { default as stripJSONcomments } from "https://cdn.skypack.dev/strip-json-comments?dts";

--- a/src/nova_deno.ts
+++ b/src/nova_deno.ts
@@ -25,14 +25,11 @@ const workspaceConfigRestartKeys = [
 ];
 
 export function activate() {
-  const workspacePath = nova.workspace.path as string;
-  const denoConfigPath = nova.path.join(workspacePath, "deno.json");
-  const configWatcher = nova.fs.watch(denoConfigPath, () => {
-    taskDisposable.dispose();
-    taskDisposable.add(registerDenoTasks());
-    nova.commands.invoke("co.gwil.deno.commands.restartServer");
-  });
-  compositeDisposable.add(configWatcher);
+  const workspacePath = nova.workspace.path;
+  if (workspacePath) {
+    watchConfigFile(workspacePath, "deno.json");
+    watchConfigFile(workspacePath, "deno.jsonc");
+  }
 
   const clientDisposable = makeClientDisposable(compositeDisposable);
 
@@ -61,6 +58,16 @@ export function activate() {
 
 export function deactivate() {
   compositeDisposable.dispose();
+}
+
+function watchConfigFile(workspacePath: string, filename: string) {
+  const denoConfigPath = nova.path.join(workspacePath, filename);
+  const configWatcher = nova.fs.watch(denoConfigPath, () => {
+    taskDisposable.dispose();
+    taskDisposable.add(registerDenoTasks());
+    nova.commands.invoke("co.gwil.deno.commands.restartServer");
+  });
+  compositeDisposable.add(configWatcher);
 }
 
 function restartServerOnConfigChanges(keys: string[]) {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -7,22 +7,32 @@ import {
   TaskProcessAction,
   Transferrable,
 } from "./nova_utils.ts";
+import { stripJSONcomments } from "../deps.ts";
 
 class DenoTaskAssistant implements TaskAssistant {
   provideTasks() {
+    return [
+      ...this.#getTasksFromFilename("deno.json"),
+      ...this.#getTasksFromFilename("deno.jsonc"),
+    ];
+  }
+
+  #getTasksFromFilename(filename: string) {
     const workspacePath = nova.workspace.path;
 
     if (!workspacePath) {
       return [];
     }
 
-    const denoConfigPath = nova.path.join(workspacePath, "deno.json");
+    const denoConfigPath = nova.path.join(workspacePath, filename);
     const denoConfigStat = nova.fs.stat(denoConfigPath);
 
     if (denoConfigStat?.isFile()) {
       try {
         const config = JSON.parse(
-          nova.fs.open(denoConfigPath).read() as string,
+          stripJSONcomments(
+            nova.fs.open(denoConfigPath).read() as string,
+          ),
         );
 
         const tasks = config["tasks"];


### PR DESCRIPTION
This pull request resolves #22 and resolves #20.

This is my first substantial contribution to someone else's software, so please be patient and forgive any issues 🙂.

These changes enable the use of the extension in project-less windows:
<img width="930" alt="Screen Shot 2022-04-30 at 1 23 32 PM" src="https://user-images.githubusercontent.com/73370025/166118059-0f78dd64-22d3-41bf-8696-b00acdfaecc7.png">

Except during editing of unsaved documents 🙁:
<img width="890" alt="Screen Shot 2022-04-30 at 1 35 37 PM" src="https://user-images.githubusercontent.com/73370025/166118295-a8a17fd3-1c75-4ce2-b563-f0096d1150c3.png">


They also cause tasks defined in `deno.jsonc` files to be displayed inside the Tasks menu:

<img width="694" alt="Screen Shot 2022-04-30 at 1 25 47 PM" src="https://user-images.githubusercontent.com/73370025/166118210-a1b2acae-f7b9-4184-8782-922c6cdc0bad.png">

I used the `strip-json-comments` NPM module to parse _JSON with comments_ files, and tried to mimic the way `vscode-languageserver-types` was imported.