### PR TITLE
Improve error handling when Deno is missing

### DIFF
--- a/src/nova_deno.ts
+++ b/src/nova_deno.ts
@@ -24,14 +24,20 @@ const workspaceConfigRestartKeys = [
   "co.gwil.deno.config.import-map",
 ];
 
-export function activate() {
+export async function activate() {
   const workspacePath = nova.workspace.path;
   if (workspacePath) {
     watchConfigFile(workspacePath, "deno.json");
     watchConfigFile(workspacePath, "deno.jsonc");
   }
 
-  const clientDisposable = makeClientDisposable(compositeDisposable);
+  let clientDisposable;
+  try {
+    clientDisposable = await makeClientDisposable(compositeDisposable);
+  } catch {
+    // This happens if the user clicks on 'Ignore' after they are requested to install Deno.
+    return;
+  }
 
   compositeDisposable.add(clientDisposable);
 


### PR DESCRIPTION
Please let me know if I'm overcomplicating things; this is just a quick experiment.

I made some changes to improve the extension's behavior when Deno isn't installed. Here's a recording from my ancient iMac, in which there's no Deno:

https://user-images.githubusercontent.com/73370025/168409263-8b84aefb-1e80-48a8-90ae-33461e38ca97.mp4

Some care needs to be taken in regard to that, if the user clicks _Ignore_, the extension's `activate` code won't be run completely.