### PR TITLE
Don't add several listeners for each editor

### DIFF
--- a/src/commands/sidebar_find_symbol.ts
+++ b/src/commands/sidebar_find_symbol.ts
@@ -314,12 +314,6 @@ class SymbolDataProvider implements TreeDataProvider<Element> {
       disposable = createEventListener(updateSymbols);
     };
 
-    for (const textEditor of nova.workspace.textEditors) {
-      updateSymbolsAndManageDisposable(
-        textEditor.onDidStopChanging.bind(textEditor),
-      );
-    }
-
     nova.workspace.onDidAddTextEditor((textEditor) =>
       updateSymbolsAndManageDisposable(
         textEditor.onDidStopChanging.bind(textEditor),


### PR DESCRIPTION
Related to, although not a solution for, #35.

The `.onDidAddTextEditor` callback is called initially for every opened editor, and that's documented!