### PR TITLE
Reducing the frequency of reloading

### DIFF
--- a/src/commands/sidebar_find_symbol.ts
+++ b/src/commands/sidebar_find_symbol.ts
@@ -17,8 +17,11 @@ let symbolDataProvider: SymbolDataProvider | null = null;
 interface ElementConversionOptions {
   shouldDisambiguate?: boolean;
 }
-type Element = File | Header | Symbol;
-class File {
+interface Element {
+  toTreeItem: (options: ElementConversionOptions) => TreeItem;
+  children: Element[];
+}
+class File implements Element {
   uri: string;
   extension: string;
   children: Symbol[];
@@ -46,7 +49,7 @@ class File {
     return item;
   }
 }
-class Header {
+class Header implements Element {
   content: string;
   children: [];
   constructor(content: string) {
@@ -59,7 +62,7 @@ class Header {
     return item;
   }
 }
-class Symbol {
+class Symbol implements Element {
   name: string;
   type: string;
   location: lsp.Location;


### PR DESCRIPTION
I have hardly tested this code! Sorry; I admit to being a little bit excited. 

These changes greatly alleviate issue #35. The tree view is now only reloaded… 

- when its symbols' names are changed and
- when symbols are added or removed.

https://user-images.githubusercontent.com/73370025/173280198-62afb47e-3372-4b16-a161-438f95adef82.mp4