### PR TITLE
Development Experience improvement and improved build process post Deno 2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nova_utils"]
+	path = nova_utils
+	url = git@github.com:sgwilym/nova_utils.git

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,11 @@
 {
-	"tasks": {
-		"build": "deno run --allow-all --unstable build.ts"
-	},
-	"imports": {
-		"lsp": "npm:vscode-languageserver-types",
-		"strip-json": "https://esm.sh/strip-json-comments",
-		"nova-utils": "../nova_utils/mod.ts"
-	},
-	"exclude": ["deno.novaextension"]
+  "tasks": {
+    "build": "deno run --allow-all build.ts"
+  },
+  "imports": {
+    "lsp": "npm:vscode-languageserver-types",
+    "strip-json": "https://esm.sh/strip-json-comments",
+    "nova-utils": "./nova_utils/mod.ts"
+  },
+  "exclude": ["deno.novaextension"]
 }


### PR DESCRIPTION
Hi Sam, I was just playing around with your extension I thought you and others might find this pull request helpful when contributing to your extension?

**Change Summary**:
- Deno moans about `-unstable-*` as it is deprecated from 2.0+ and wanting specificity regarding this flag
   - I ran `Deno run build` without this flag and all seems to be fine, so I think it should be redundant?
- I have also added the `sgwilym/nova_utils` as a submodule
   - The build step depends on your `nova-utils` anyways. Previously it is assumed that `nova-utils` existed in the parent directory


I hope you find this pull request helpful 😊